### PR TITLE
TRITON-2327/TRITON-2325 Update sshpk for CVE-2018-3737 and vasync for CVE-2021-3918

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "deps/jsstyle"]
 	path = deps/jsstyle
-	url = https://github.com/joyent/jsstyle.git
+	url = https://github.com/TritonDataCenter/jsstyle.git
 [submodule "deps/restdown"]
 	path = deps/restdown
-	url = https://github.com/trentm/restdown.git
+	url = https://github.com/TritonDataCenter/restdown.git
 [submodule "deps/javascriptlint"]
 	path = deps/javascriptlint
-	url = https://github.com/davepacheco/javascriptlint.git
+	url = https://github.com/TritonDataCenter/javascriptlint.git

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Joyent Authentication Library
+# Triton Authentication Library
 
-Utility functions to sign http requests to Joyent Triton and Manta services.
+Utility functions to sign http requests to Triton and Manta services.
 This library is meant to be used internally by other libraries and tools as in
-the [`triton`](https://github.com/joyent/node-triton) and
-[Manta](https://github.com/joyent/node-manta) repositories.
+the [`triton`](https://github.com/TritonDataCenter/node-triton) and
+[Manta](https://github.com/TritonDataCenter/node-manta) repositories.
 
-If you only want to use one of these libraries to make requests to a Joyent
+If you only want to use one of these libraries to make requests to a Triton
 service, you should not need to use this library directly at all.
 
 Its API can be used independently, though, to search for and list the available
@@ -81,8 +81,8 @@ keyRing.findSigningKeyPair(fp, function (err, keyPair) {
 
 ## Overview
 
-Authentication to Triton CloudAPI and Manta is built on top of Joyent's
-[http-signature](https://github.com/joyent/node-http-signature) specification.
+Authentication to Triton CloudAPI and Manta is built on top of the
+[http-signature](https://github.com/TritonDataCenter/node-http-signature) specification.
 All requests to the APIs require an HTTP Authorization header where the scheme is
 `Signature`.  Full details are available in the `http-signature` specification,
 but a simple form is:
@@ -328,7 +328,7 @@ an issue on this repo).
 
 The `keyId` fingerprint does not necessarily need to be the exact format
 (hex MD5) as sent to the server -- it can be in any fingerprint format supported
-by the [`sshpk`](https://github.com/arekinath/node-sshpk) library.
+by the [`sshpk`](https://github.com/TritonDataCenter/node-sshpk) library.
 
 As of version 2.0.0, an invalid fingerprint (one that can never match any key,
 because, for example, it contains invalid characters) will produce an exception
@@ -345,4 +345,4 @@ MIT.
 
 ## Bugs
 
-See <https://github.com/joyent/node-smartdc-auth/issues>.
+See <https://github.com/TritonDataCenter/node-smartdc-auth/issues>.

--- a/lib/kr-agent.js
+++ b/lib/kr-agent.js
@@ -26,7 +26,6 @@ var mod_util = require('util');
 var mod_assert = require('assert-plus');
 var mod_sshpk = require('sshpk');
 var mod_agent = require('sshpk-agent');
-var mod_vasync = require('vasync');
 var mod_errors = require('./errors');
 var KeyRingPlugin = require('./krplugin');
 

--- a/lib/kr-file.js
+++ b/lib/kr-file.js
@@ -29,7 +29,6 @@ var mod_fs = require('fs');
 var mod_path = require('path');
 var mod_errors = require('./errors');
 var KeyRingPlugin = require('./krplugin');
-var mod_vasync = require('vasync');
 
 var mod_keypair = require('./keypair');
 var KeyPair = mod_keypair.KeyPair;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "smartdc-auth",
-    "description": "Joyent Authentication Library",
-    "version": "2.5.8",
-    "author": "Joyent (joyent.com)",
+    "description": "Triton Authentication Library",
+    "version": "2.5.9",
+    "author": "MNX Cloud (mnx.io)",
+    "license": "MIT",
     "contributors": [
         "Mark Cavage",
         "Nate Fitch",
@@ -13,7 +14,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/joyent/node-smartdc-auth.git"
+        "url": "https://github.com/TritonDataCenter/node-smartdc-auth.git"
     },
     "main": "lib/index.js",
     "scripts": {
@@ -34,8 +35,8 @@
         "http-signature": "^1.0.2",
         "once": "1.3.0",
         "sshpk-agent": "^1.3.0",
-        "sshpk": "^1.8.3",
-        "vasync": "1.4.3"
+        "sshpk": "^1.13.2",
+        "vasync": "^2.2.1"
     },
     "devDependencies": {
         "tape": ">=4.2.0 <5.0.0",

--- a/test/agent-keys.test.js
+++ b/test/agent-keys.test.js
@@ -1,4 +1,5 @@
 // Copyright 2015 Joyent, Inc.  All rights reserved.
+// Copyright 2022 MNX Cloud, Inc.
 
 var test = require('tape').test;
 
@@ -19,9 +20,9 @@ var ID_DSA_MD5 = 'a6:e6:68:d3:28:2b:0a:a0:12:54:da:c4:c0:22:8d:ba';
 var ID_ECDSA_FP = 'SHA256:ezilZp/ZHJuMF8i9jyMGuxRdFCu4rzGYLQmfSOhrolE';
 var ID_ECDSA_MD5 = '00:74:32:ae:0a:24:3c:7a:e7:07:b8:ee:91:c4:c7:27';
 
-var SIG_RSA_SHA1 = 'parChQDdkj8wFY75IUW/W7KN9q5FFTPYfcAf+W7PmN8yxnRJB884NHYNT' +
-    'hl/TjZB2s0vt+kkfX3nldi54heTKbDKFwCOoDmVWQ2oE2ZrJPPFiUHReUAIRvwD0V/q7' +
-    '4c/DiRR6My7FEa8Szce27DBrjBmrMvMcmd7/jDbhaGusy4=';
+var SIG_RSA_SHA256 = 'KX1okEE5wWjgrDYM35z9sO49WRk/DeZy7QeSNCFdOsn45BO6rVOIH5vV7' +
+    'WD25/VWyGCiN86Pml/Eulhx3Xx4ZUEHHc18K0BAKU5CSu/jCRI0dEFt4q1bXCyM7aKFlAXpk' +
+    '7CJIM0Gx91CJEXcZFuUddngoqljyt9hu4dpMhrjVFA=';
 
 /* automatically clean up temp dir at exit */
 temp.track();
@@ -86,9 +87,9 @@ test('agentsigner rsa', function (t) {
         sign('foobar', function (err, sigData) {
             t.error(err);
             t.strictEqual(sigData.keyId, ID_RSA_MD5);
-            t.strictEqual(sigData.algorithm, 'rsa-sha1');
+            t.strictEqual(sigData.algorithm, 'rsa-sha256');
             t.strictEqual(sigData.user, 'foo');
-            t.strictEqual(sigData.signature, SIG_RSA_SHA1);
+            t.strictEqual(sigData.signature, SIG_RSA_SHA256);
             t.end();
         });
     });
@@ -159,9 +160,9 @@ test('clisigner with only agent', function (t) {
     sign('foobar', function (err, sigData) {
         t.error(err);
         t.strictEqual(sigData.keyId, ID_RSA_MD5);
-        t.strictEqual(sigData.algorithm, 'rsa-sha1');
+        t.strictEqual(sigData.algorithm, 'rsa-sha256');
         t.strictEqual(sigData.user, 'foo');
-        t.strictEqual(sigData.signature, SIG_RSA_SHA1);
+        t.strictEqual(sigData.signature, SIG_RSA_SHA256);
         t.end();
     });
 });
@@ -228,8 +229,8 @@ test('cliSigner using agent with lots of keys (TOOLS-1214)', function (t) {
         t.strictEqual(sigData.keyId,
             bulkKeys[2].fingerprint('md5').toString('hex'));
         t.strictEqual(sigData.user, 'foo');
-        t.strictEqual(sigData.algorithm, 'rsa-sha1');
-        var v = bulkKeys[2].createVerify('sha1');
+        t.strictEqual(sigData.algorithm, 'rsa-sha256');
+        var v = bulkKeys[2].createVerify('sha256');
         v.update('foobar');
         t.ok(v.verify(sigData.signature, 'base64'));
         t.end();


### PR DESCRIPTION
Unit tests were failing before attempting the dependcy updates, using a `git bisect` it appears that they have been failing since 3f0b829a3e8a9e87b95b3e0fded48428b4762da6 that commit also had a failed [Travis CI](https://travis-ci.org/github/joyent/node-smartdc-auth/jobs/153447276) build but sadly the logs are no longer present.

Updating the SHA hash and replacing rsa-sha1 with rsa-sha256 resolves the failing tests.

After updating both sshpk and vasync all tests continue to pass. I also looked for any possible fallout from the [vasync v2.0.0 breaking changes](https://github.com/TritonDataCenter/node-vasync/blob/master/CHANGES.md#v200) but no usage of the impacted functions were encountered. During that review I found that the vasync module was being required in 2 files where it was not being used and I removed the require statements.

Also added MIT license to package.json to silence NPM warnings about lack of license.

**make check:**

```
# make check
deps/javascriptlint/build/install/jsl --nologo --nosummary --conf=tools/jsl.node.conf lib/keypair.js lib/kr-agent.js lib/keyring.js lib/krplugin.js lib/kr-file.js lib/errors.js lib/index.js lib/kr-homedir.js
/root/node-smartdc-auth/lib/keypair.js
/root/node-smartdc-auth/lib/kr-agent.js
/root/node-smartdc-auth/lib/keyring.js
/root/node-smartdc-auth/lib/krplugin.js
/root/node-smartdc-auth/lib/kr-file.js
/root/node-smartdc-auth/lib/errors.js
/root/node-smartdc-auth/lib/index.js
/root/node-smartdc-auth/lib/kr-homedir.js
deps/jsstyle/jsstyle -f tools/jsstyle.conf lib/keypair.js lib/kr-agent.js lib/keyring.js lib/krplugin.js lib/kr-file.js lib/errors.js lib/index.js lib/kr-homedir.js
check ok
```


**make test:**

```
# make test
npm install
audited 109 packages in 4.793s
found 0 vulnerabilities

./node_modules/.bin/tape test/*.test.js
TAP version 13
# setup
# agentsigner throws with no agent
ok 1 should throw
# agent setup
# agentsigner with empty agent
ok 2 should be truthy
ok 3 should be truthy
ok 4 should be truthy
ok 5 should be truthy
# agentsigner rsa
ok 6 should be truthy
ok 7 null
ok 8 should be truthy
ok 9 null
ok 10 should be equal
ok 11 should be equal
ok 12 should be equal
ok 13 should be equal
# agentsigner dsa
ok 14 should be truthy
ok 15 null
ok 16 should be truthy
ok 17 null
ok 18 should be equal
ok 19 should be equal
ok 20 should be equal
ok 21 should be truthy
# agentsigner ecdsa + buffer
ok 22 should be truthy
ok 23 null
ok 24 should be truthy
ok 25 null
ok 26 should be equal
ok 27 should be equal
ok 28 should be equal
ok 29 should be truthy
# clisigner with only agent
ok 30 should be truthy
ok 31 should be truthy
ok 32 null
ok 33 should be equal
ok 34 should be equal
ok 35 should be equal
ok 36 should be equal
# generate 40 keys (for TOOLS-1214)
ok 37 should be truthy
ok 38 null
ok 39 null
# cliSigner using agent with lots of keys (TOOLS-1214)
ok 40 should be truthy
ok 41 should be truthy
ok 42 null
ok 43 should be equal
ok 44 should be equal
ok 45 should be equal
ok 46 should be truthy
# agent teardown
ok 47 should be truthy
# setup
ok 48 null
ok 49 null
# loadSSHKey full pair
ok 50 null
ok 51 should be equal
ok 52 should be equal
ok 53 should be equal
# loadSSHKey public only
ok 54 should be truthy
ok 55 should be truthy
# keyring cannot sign
ok 56 should be truthy
ok 57 null
ok 58 should be equal
ok 59 should be truthy
# loadSSHKey private only rsa
ok 60 null
# loadSSHKey private only dsa
ok 61 null
ok 62 should be equal
ok 63 should be equal
# keyring basic
ok 64 null
ok 65 should be truthy
ok 66 should be truthy
# setup encrypted
ok 67 null
# keyring unlock
ok 68 null
ok 69 should be truthy
ok 70 should be truthy
ok 71 should be truthy
# file plugin
ok 72 null
ok 73 should be truthy
ok 74 should be truthy
# loadSSHKey enc-private full pair
ok 75 should be truthy
ok 76 should not be equal
# loadSSHKey enc-private private only
ok 77 should be truthy
# loadSSHKey enc-private other key
ok 78 null
# teardown
# setup fs only
ok 79 null
ok 80 null
# basic cliSigner rsa
ok 81 should be truthy
ok 82 null
ok 83 should be equal
ok 84 should be equal
ok 85 should be equal
ok 86 should be equal
# KeyRing signer rsa
ok 87 null
ok 88 null
ok 89 should be equal
ok 90 should be equal
ok 91 should be equal
ok 92 should be truthy
# KeyRing list keys
ok 93 null
ok 94 should be equal
ok 95 should be equal
ok 96 should be truthy
ok 97 should be equal
ok 98 should be truthy
# requestSigner rsa
ok 99 should be truthy
ok 100 null
ok 101 should be equal
ok 102 should be equal
ok 103 should be equal
ok 104 should be truthy
# requestSigner with premade cliSigner
ok 105 should be truthy
ok 106 should be truthy
ok 107 null
ok 108 should be equal
ok 109 should be equal
ok 110 should be equal
ok 111 should be truthy
# requestSigner with custom signer
ok 112 should be truthy
ok 113 null
ok 114 should be equal
ok 115 should be equal
ok 116 should be equal
ok 117 should be equal
# basic cliSigner dsa
ok 118 should be truthy
ok 119 null
ok 120 should be equal
ok 121 should be equal
ok 122 should be equal
ok 123 should be truthy
# basic cliSigner with algorithm and subuser
ok 124 should be truthy
ok 125 null
ok 126 should be equal
ok 127 should be equal
ok 128 should be equal
ok 129 should be equal
ok 130 should be equal
# cliSigner unknown fp
ok 131 should be truthy
ok 132 should be truthy
ok 133 should be truthy
# cliSigner invalid fp
ok 134 should throw
ok 135 should throw
# teardown

1..135
# tests 135
# pass  135

# ok
```